### PR TITLE
Support for non-Float64 eltypes when using ForwardDiff

### DIFF
--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -36,12 +36,12 @@ Wrap a log density that supports evaluation of `Value` to handle `ValueGradient`
 Keywords are passed on to `ForwardDiff.GradientConfig` to customize the setup. In
 particular, chunk size can be set with a `chunk` keyword argument (accepting an integer or a
 `ForwardDiff.Chunk`), and the underlying vector used by `ForwardDiff` can be set with the
-`input` keyword argument (accepting an `AbstractVector`).
+`x` keyword argument (accepting an `AbstractVector`).
 """
 function ADgradient(::Val{:ForwardDiff}, ℓ;
-                    input = zeros(dimension(ℓ)),
+                    x = zeros(dimension(ℓ)),
                     chunk = _default_chunk(ℓ),
-                    gradientconfig = _default_gradientconfig(ℓ, chunk, input))
+                    gradientconfig = _default_gradientconfig(ℓ, chunk, x))
     ForwardDiffLogDensity(ℓ, gradientconfig)
 end
 

--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -18,28 +18,30 @@ end
 
 _default_chunk(ℓ) = ForwardDiff.Chunk(dimension(ℓ))
 
-function _default_gradientconfig(ℓ, chunk::ForwardDiff.Chunk)
-    ForwardDiff.GradientConfig(Base.Fix1(logdensity, ℓ), zeros(dimension(ℓ)), chunk)
+function _default_gradientconfig(ℓ, chunk::ForwardDiff.Chunk, x::AbstractVector)
+    return ForwardDiff.GradientConfig(Base.Fix1(logdensity, ℓ), x, chunk)
 end
 
-function _default_gradientconfig(ℓ, chunk::Integer)
-    _default_gradientconfig(ℓ, ForwardDiff.Chunk(chunk))
+function _default_gradientconfig(ℓ, chunk::Integer, x::AbstractVector)
+    return _default_gradientconfig(ℓ, ForwardDiff.Chunk(chunk), x)
 end
 
 """
-    ADgradient(:ForwardDiff, ℓ; chunk, gradientconfig)
-    ADgradient(Val(:ForwardDiff), ℓ; chunk, gradientconfig)
+    ADgradient(:ForwardDiff, ℓ; input, chunk, gradientconfig)
+    ADgradient(Val(:ForwardDiff), ℓ; input, chunk, gradientconfig)
 
 Wrap a log density that supports evaluation of `Value` to handle `ValueGradient`, using
 `ForwardDiff`.
 
 Keywords are passed on to `ForwardDiff.GradientConfig` to customize the setup. In
 particular, chunk size can be set with a `chunk` keyword argument (accepting an integer or a
-`ForwardDiff.Chunk`).
+`ForwardDiff.Chunk`), and the underlying vector used by `ForwardDiff` can be set with the
+`input` keyword argument (accepting an `AbstractVector`).
 """
 function ADgradient(::Val{:ForwardDiff}, ℓ;
+                    input = zeros(dimension(ℓ)),
                     chunk = _default_chunk(ℓ),
-                    gradientconfig = _default_gradientconfig(ℓ, chunk))
+                    gradientconfig = _default_gradientconfig(ℓ, chunk, input))
     ForwardDiffLogDensity(ℓ, gradientconfig)
 end
 

--- a/src/AD_ForwardDiff.jl
+++ b/src/AD_ForwardDiff.jl
@@ -27,8 +27,8 @@ function _default_gradientconfig(ℓ, chunk, x::AbstractVector)
 end
 
 """
-    ADgradient(:ForwardDiff, ℓ; input, chunk, gradientconfig)
-    ADgradient(Val(:ForwardDiff), ℓ; input, chunk, gradientconfig)
+    ADgradient(:ForwardDiff, ℓ; x, chunk, gradientconfig)
+    ADgradient(Val(:ForwardDiff), ℓ; x, chunk, gradientconfig)
 
 Wrap a log density that supports evaluation of `Value` to handle `ValueGradient`, using
 `ForwardDiff`.
@@ -39,9 +39,9 @@ particular, chunk size can be set with a `chunk` keyword argument (accepting an 
 `x` keyword argument (accepting an `AbstractVector`).
 """
 function ADgradient(::Val{:ForwardDiff}, ℓ;
-                    x = nothing,
-                    chunk = _default_chunk(ℓ),
-                    gradientconfig = _default_gradientconfig(ℓ, chunk, x))
+                    x::Union{Nothing,AbstractVector} = nothing,
+                    chunk::Union{Integer,ForwardDiff.Chunk} = _default_chunk(ℓ),
+                    gradientconfig::ForwardDiff.GradientConfig = _default_gradientconfig(ℓ, chunk, x))
     ForwardDiffLogDensity(ℓ, gradientconfig)
 end
 

--- a/src/DiffResults_helpers.jl
+++ b/src/DiffResults_helpers.jl
@@ -13,7 +13,7 @@ Allocate a DiffResults buffer for a gradient, taking the element type of `x` int
 """
 function _diffresults_buffer(x)
     T = eltype(x)
-    S = T <: Real ? float(Real) : Float64 # heuristic
+    S = T <: Real ? float(T) : Float64 # heuristic
     DiffResults.MutableDiffResult(zero(S), (similar(x, S), ))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ end
 
     # Make sure that other types are supported.
     x = randexp(Float32, 3)
-    ∇ℓ = ADgradient(:ForwardDiff, ℓ; input=x)
+    ∇ℓ = ADgradient(:ForwardDiff, ℓ; x=x)
     @test eltype(first(logdensity_and_gradient(∇ℓ, x))) === Float32
     @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
     @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅


### PR DESCRIPTION
See tests for example + things like

``` julia
x = ComponentVector(x = zeros(3))
∇ℓ = ADgradient(:ForwardDiff, ℓ; input=x)
```

also works.