### PR TITLE
Use SimpleUnPack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [weakdeps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -30,7 +30,7 @@ julia = "1.6"
 DocStringExtensions = "0.8, 0.9"
 LogDensityProblems = "1, 2"
 Requires = "0.5, 1"
-UnPack = "0.1, 1"
+SimpleUnPack = "1"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/ext/LogDensityProblemsADEnzymeExt.jl
+++ b/ext/LogDensityProblemsADEnzymeExt.jl
@@ -4,7 +4,7 @@ Gradient AD implementation using Enzyme.
 module LogDensityProblemsADEnzymeExt
 
 using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.UnPack: @unpack
+using LogDensityProblemsAD.SimpleUnPack: @unpack
 
 import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
 if EXTENSIONS_SUPPORTED

--- a/ext/LogDensityProblemsADForwardDiffExt.jl
+++ b/ext/LogDensityProblemsADForwardDiffExt.jl
@@ -4,7 +4,7 @@ Gradient AD implementation using ForwardDiff.
 module LogDensityProblemsADForwardDiffExt
 
 using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, SIGNATURES, dimension, logdensity
-using LogDensityProblemsAD.UnPack: @unpack
+using LogDensityProblemsAD.SimpleUnPack: @unpack
 
 import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
 if EXTENSIONS_SUPPORTED

--- a/ext/LogDensityProblemsADReverseDiffExt.jl
+++ b/ext/LogDensityProblemsADReverseDiffExt.jl
@@ -4,7 +4,7 @@ Gradient AD implementation using ReverseDiff.
 module LogDensityProblemsADReverseDiffExt
 
 using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, SIGNATURES, dimension, logdensity
-using LogDensityProblemsAD.UnPack: @unpack
+using LogDensityProblemsAD.SimpleUnPack: @unpack
 
 import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
 if EXTENSIONS_SUPPORTED

--- a/ext/LogDensityProblemsADTrackerExt.jl
+++ b/ext/LogDensityProblemsADTrackerExt.jl
@@ -4,7 +4,7 @@ Gradient AD implementation using Tracker.
 module LogDensityProblemsADTrackerExt
 
 using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.UnPack: @unpack
+using LogDensityProblemsAD.SimpleUnPack: @unpack
 
 import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
 if EXTENSIONS_SUPPORTED

--- a/ext/LogDensityProblemsADZygoteExt.jl
+++ b/ext/LogDensityProblemsADZygoteExt.jl
@@ -4,7 +4,7 @@ Gradient AD implementation using Zygote.
 module LogDensityProblemsADZygoteExt
 
 using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.UnPack: @unpack
+using LogDensityProblemsAD.SimpleUnPack: @unpack
 
 import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
 if EXTENSIONS_SUPPORTED

--- a/src/LogDensityProblemsAD.jl
+++ b/src/LogDensityProblemsAD.jl
@@ -9,7 +9,7 @@ using DocStringExtensions: SIGNATURES
 import LogDensityProblems: logdensity, logdensity_and_gradient, capabilities, dimension
 using LogDensityProblems: LogDensityOrder
 
-import UnPack
+import SimpleUnPack
 
 
 #####


### PR DESCRIPTION
As explained in https://github.com/tpapp/LogDensityProblems.jl/pull/103, switching from UnPack to SimpleUnPack should reduce the number of specializations.