### PR TITLE
Only use relative imports with Requires

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/ext/LogDensityProblemsADEnzymeExt.jl
+++ b/ext/LogDensityProblemsADEnzymeExt.jl
@@ -3,13 +3,17 @@ Gradient AD implementation using Enzyme.
 """
 module LogDensityProblemsADEnzymeExt
 
-using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.SimpleUnPack: @unpack
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
-import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
-if EXTENSIONS_SUPPORTED
+    import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import Enzyme
 else
+    using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
+
+    import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Enzyme
 end
 

--- a/ext/LogDensityProblemsADForwardDiffBenchmarkToolsExt.jl
+++ b/ext/LogDensityProblemsADForwardDiffBenchmarkToolsExt.jl
@@ -5,17 +5,19 @@ Loaded when both ForwardDiff and BenchmarkTools are loaded.
 """
 module LogDensityProblemsADForwardDiffBenchmarkToolsExt
 
-using LogDensityProblemsAD: ADgradient, EXTENSIONS_SUPPORTED, SIGNATURES, dimension, logdensity_and_gradient
-
-if EXTENSIONS_SUPPORTED
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADgradient, SIGNATURES, dimension, logdensity_and_gradient
     using BenchmarkTools: @belapsed
     using ForwardDiff: Chunk
+
+    import LogDensityProblemsAD: benchmark_ForwardDiff_chunks, heuristic_chunks
 else
+    using ..LogDensityProblemsAD: ADgradient, SIGNATURES, dimension, logdensity_and_gradient
     using ..BenchmarkTools: @belapsed
     using ..ForwardDiff: Chunk
-end
 
-import LogDensityProblemsAD: benchmark_ForwardDiff_chunks, heuristic_chunks
+    import ..LogDensityProblemsAD: benchmark_ForwardDiff_chunks, heuristic_chunks
+end
 
 """
 $(SIGNATURES)

--- a/ext/LogDensityProblemsADForwardDiffExt.jl
+++ b/ext/LogDensityProblemsADForwardDiffExt.jl
@@ -3,14 +3,18 @@ Gradient AD implementation using ForwardDiff.
 """
 module LogDensityProblemsADForwardDiffExt
 
-using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, SIGNATURES, dimension, logdensity
-using LogDensityProblemsAD.SimpleUnPack: @unpack
-
-import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
-if EXTENSIONS_SUPPORTED
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
+    using LogDensityProblemsAD.SimpleUnPack: @unpack
+    
+    import LogDensityProblemsAD: ADgradient, logdensity_and_gradient    
     import ForwardDiff
     import ForwardDiff: DiffResults
 else
+    using ..LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
+    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
+    
+    import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient    
     import ..ForwardDiff
     import ..ForwardDiff: DiffResults
 end

--- a/ext/LogDensityProblemsADReverseDiffExt.jl
+++ b/ext/LogDensityProblemsADReverseDiffExt.jl
@@ -3,14 +3,18 @@ Gradient AD implementation using ReverseDiff.
 """
 module LogDensityProblemsADReverseDiffExt
 
-using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, SIGNATURES, dimension, logdensity
-using LogDensityProblemsAD.SimpleUnPack: @unpack
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
+    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
-import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
-if EXTENSIONS_SUPPORTED
+    import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ReverseDiff
     import ReverseDiff: DiffResults
 else
+    using ..LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
+    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
+
+    import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..ReverseDiff
     import ..ReverseDiff: DiffResults
 end

--- a/ext/LogDensityProblemsADTrackerExt.jl
+++ b/ext/LogDensityProblemsADTrackerExt.jl
@@ -3,13 +3,17 @@ Gradient AD implementation using Tracker.
 """
 module LogDensityProblemsADTrackerExt
 
-using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.SimpleUnPack: @unpack
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
-import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
-if EXTENSIONS_SUPPORTED
+    import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import Tracker
 else
+    using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
+
+    import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Tracker
 end
 

--- a/ext/LogDensityProblemsADZygoteExt.jl
+++ b/ext/LogDensityProblemsADZygoteExt.jl
@@ -3,13 +3,17 @@ Gradient AD implementation using Zygote.
 """
 module LogDensityProblemsADZygoteExt
 
-using LogDensityProblemsAD: ADGradientWrapper, EXTENSIONS_SUPPORTED, logdensity
-using LogDensityProblemsAD.SimpleUnPack: @unpack
-
-import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
-if EXTENSIONS_SUPPORTED
+if isdefined(Base, :get_extension)
+    using LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using LogDensityProblemsAD.SimpleUnPack: @unpack
+    
+    import LogDensityProblemsAD: ADgradient, logdensity_and_gradient    
     import Zygote
 else
+    using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
+    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
+
+    import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Zygote
 end
 


### PR DESCRIPTION
I learnt recently that one should always use relative imports with Requires if one wants to support building sysimages (https://github.com/JuliaArrays/ArrayInterface.jl/pull/387).