### PR TITLE
Add support for ADTypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -10,6 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [weakdeps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
@@ -19,6 +20,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
+LogDensityProblemsADADTypesExt = "ADTypes"
 LogDensityProblemsADEnzymeExt = "Enzyme"
 LogDensityProblemsADFiniteDifferencesExt = "FiniteDifferences"
 LogDensityProblemsADForwardDiffBenchmarkToolsExt = ["BenchmarkTools", "ForwardDiff"]
@@ -28,6 +30,7 @@ LogDensityProblemsADTrackerExt = "Tracker"
 LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
+ADTypes = "0.1.5"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11"
 FiniteDifferences = "0.12"
@@ -37,6 +40,7 @@ SimpleUnPack = "1"
 julia = "1.6"
 
 [extras]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
@@ -49,4 +53,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["BenchmarkTools", "ComponentArrays", "Enzyme", "FiniteDifferences", "ForwardDiff", "Random", "ReverseDiff", "Test", "Tracker", "Zygote"]
+test = ["ADTypes", "BenchmarkTools", "ComponentArrays", "Enzyme", "FiniteDifferences", "ForwardDiff", "Random", "ReverseDiff", "Test", "Tracker", "Zygote"]

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -1,0 +1,48 @@
+module LogDensityProblemsADADTypesExt
+
+import LogDensityProblemsAD
+import ADTypes
+
+"""
+    ADgradient(ad::ADTypes.AbstractADType, ℓ)
+
+Wrap log density `ℓ` using automatic differentiation (AD) of type `ad` to obtain a gradient.
+
+Currently,
+- `ad::ADTypes.AutoEnzyme`
+- `ad::ADTypes.AutoForwardDiff`
+- `ad::ADTypes.AutoReverseDiff`
+- `ad::ADTypes.AutoTracker`
+- `ad::ADTypes.AutoZygote`
+are supported.
+The AD configuration specified by `ad` is forwarded to the corresponding calls of `ADgradient(Val(...), ℓ)`.    
+"""
+LogDensityProblemsAD.ADgradient(::ADTypes.AbstractADType, ℓ)
+
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoEnzyme, ℓ)
+    return LogDensityProblemsAD.ADgradient(Val(:Enzyme), ℓ)
+end
+
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoForwardDiff{C}, ℓ) where {C}
+    if C === nothing
+        # Use default chunk size
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ)
+    else
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; chunk = C)
+    end
+end
+
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff, ℓ)
+    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(ad.compile))
+end
+
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ)
+    return LogDensityProblemsAD.ADgradient(Val(:Tracker), ℓ)
+end
+
+
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoZygote, ℓ)
+    return LogDensityProblemsAD.ADgradient(Val(:Zygote), ℓ)
+end
+
+end # module

--- a/src/LogDensityProblemsAD.jl
+++ b/src/LogDensityProblemsAD.jl
@@ -84,6 +84,7 @@ if !EXTENSIONS_SUPPORTED
 end
 @static if !EXTENSIONS_SUPPORTED
     function __init__()
+        @require ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b" include("../ext/LogDensityProblemsADADTypesExt.jl")
         @require FiniteDifferences="26cc04aa-876d-5657-8c51-4c34ba976000" include("../ext/LogDensityProblemsADFiniteDifferencesExt.jl")
         @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
             include("../ext/LogDensityProblemsADForwardDiffExt.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,10 +3,11 @@ using Test, Random
 import LogDensityProblems: capabilities, dimension, logdensity
 using LogDensityProblems: logdensity_and_gradient, LogDensityOrder
 import FiniteDifferences, ForwardDiff, Enzyme, Tracker, Zygote, ReverseDiff # backends
+import ADTypes # load support for AD types with options
 import BenchmarkTools                            # load the heuristic chunks code
 using ComponentArrays: ComponentVector           # test with other vector types
 
-struct EnzymeTestMode <: Enzyme.Mode end
+struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI} end
 
 ####
 #### test setup and utilities
@@ -72,11 +73,18 @@ dimension(::TestLogDensity2) = 20
         @test repr(∇ℓ) == "ReverseDiff AD wrapper for " * repr(ℓ) * " (no compiled tape)"
     end
 
+    # ADTypes support
+    @test ADgradient(ADTypes.AutoReverseDiff(), ℓ) === ∇ℓ_default
+    @test ADgradient(ADTypes.AutoReverseDiff(; compile = false), ℓ) === ∇ℓ_nocompile
+
     ∇ℓ_compile = ADgradient(:ReverseDiff, ℓ; compile=Val(true))
     ∇ℓ_compile_x = ADgradient(:ReverseDiff, ℓ; compile=Val(true), x=rand(3))
     for ∇ℓ in (∇ℓ_compile, ∇ℓ_compile_x)
         @test repr(∇ℓ) == "ReverseDiff AD wrapper for " * repr(ℓ) * " (compiled tape)"
     end
+
+    # ADTypes support
+    @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = true), ℓ)) === typeof(∇ℓ_compile)
 
     for ∇ℓ in (∇ℓ_default, ∇ℓ_nocompile, ∇ℓ_compile, ∇ℓ_compile_x)
         @test dimension(∇ℓ) == 3
@@ -116,6 +124,9 @@ end
             (test_logdensity(x), test_gradient(x))
     end
 
+    # ADTypes support
+    @test ADgradient(ADTypes.AutoForwardDiff(), ℓ) === ∇ℓ
+
     # preallocated gradient config
     x = randexp(Float32, 3)
     ∇ℓ = ADgradient(:ForwardDiff, ℓ; x = x)
@@ -127,6 +138,9 @@ end
 
     # chunk size as integers
     @test ADgradient(:ForwardDiff, ℓ; chunk = 3) isa eltype(∇ℓ)
+
+    # ADTypes support
+    @test ADgradient(ADTypes.AutoForwardDiff(3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
 end
 
 @testset "component vectors" begin
@@ -160,6 +174,9 @@ end
         @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
         @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅ (test_logdensity(x), test_gradient(x))
    end
+
+   # ADTypes support
+   @test ADgradient(ADTypes.AutoTracker(), ℓ) === ∇ℓ
 end
 
 @testset "AD via Zygote" begin
@@ -173,6 +190,9 @@ end
         @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity1(x)
         @test logdensity_and_gradient(∇ℓ, x) ≅ (test_logdensity1(x), test_gradient(x))
     end
+
+   # ADTypes support
+   @test ADgradient(ADTypes.AutoZygote(), ℓ) === ∇ℓ
 end
 
 @testset "AD via Enzyme" begin
@@ -181,6 +201,9 @@ end
     ∇ℓ_reverse = ADgradient(:Enzyme, ℓ)
     @test ∇ℓ_reverse === ADgradient(:Enzyme, ℓ; mode=Enzyme.Reverse)
     @test repr(∇ℓ_reverse) == "Enzyme AD wrapper for " * repr(ℓ) * " with reverse mode"
+
+    # ADTypes support
+    @test ADgradient(ADTypes.AutoEnzyme(), ℓ) === ∇ℓ_reverse
 
     ∇ℓ_forward = ADgradient(:Enzyme, ℓ; mode=Enzyme.Forward)
     ∇ℓ_forward_shadow = ADgradient(:Enzyme, ℓ;


### PR DESCRIPTION
In Turing, we bundle all AD options in specific "AD backend" types to make it more convenient to pass them around and re-use them. Currently, we have to unpack them internally when calling the default `ADgradient` implementations in LogDensityProblemsAD.

This PR adds support for ADTypes, a similar system of AD types used in the SciML ecosystem. While - yet - it does neither support all options desired in Turing nor all options that can be specified in LogDensityProblemsAD, I thought it would be better to use an existing type system instead of coming up with another package of similar types in the Turing ecosystem. (My plan is then to also replace the Turing-internal types with ADTypes, once all our use cases are covered.)