### PR TITLE
Support input-dependent ForwardDiff tags

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"


### PR DESCRIPTION
The ForwardDiff tags are by default dependent on the type of the input (see, e.g., https://github.com/JuliaDiff/ForwardDiff.jl/blob/e3670ce9055c66863f655d2bac2d6615c165d838/src/config.jl#L120 and https://www.stochasticlifestyle.com/improved-forwarddiff-jl-stacktraces-with-package-tags/). This is typically also the case for custom tags (see, e.g., again https://www.stochasticlifestyle.com/improved-forwarddiff-jl-stacktraces-with-package-tags/ and https://github.com/TuringLang/Turing.jl/blob/e32bb71accb4d71dfc5f0377984a00aa5d643c3a/src/Turing.jl#L30-L36).

Unfortunately, with the current setup in LogDensityProblemsAD one can only specify the exact `ForwardDiff.Tag` and hence packages such as Turing have to compute it based on the type of the input and then forward it to `ADgradient` (see https://github.com/TuringLang/Turing.jl/blob/e32bb71accb4d71dfc5f0377984a00aa5d643c3a/src/essential/ad.jl#L96).

With this PR the whole procedure becomes more convenient for downstream packages: If the specified `tag` is not a `ForwardDiff.Tag`, the gradient computations will use `ForwardDiff.Tag(tag, eltype(x))` instead. Thus the element type of `x` is taken into consideration automatically.