### PR TITLE
Fix ADTypes extension in Julia < 1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -1,7 +1,12 @@
 module LogDensityProblemsADADTypesExt
 
-import LogDensityProblemsAD
-import ADTypes
+if isdefined(Base, :get_extension)
+    import LogDensityProblemsAD
+    import ADTypes
+else
+    import ..LogDensityProblemsAD
+    import ..ADTypes
+end
 
 """
     ADgradient(ad::ADTypes.AbstractADType, ℓ)


### PR DESCRIPTION
On Julia < 1.9, currently loading ADTypes yields an error because `ADTypes` is loaded incorrectly.