### PR TITLE
Support ADTypes 2 and AutoForwardDiff tags

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ LogDensityProblemsADTrackerExt = "Tracker"
 LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
-ADTypes = "0.1.5, 0.2"
+ADTypes = "0.1.7, 0.2"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11"
 FiniteDifferences = "0.12"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.6.1"
+version = "1.7.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -30,7 +30,7 @@ LogDensityProblemsADTrackerExt = "Tracker"
 LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
-ADTypes = "0.1.5"
+ADTypes = "0.1.5, 0.2"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11"
 FiniteDifferences = "0.12"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -28,12 +28,12 @@ function LogDensityProblemsAD.ADgradient(::ADTypes.AutoEnzyme, ℓ)
     return LogDensityProblemsAD.ADgradient(Val(:Enzyme), ℓ)
 end
 
-function LogDensityProblemsAD.ADgradient(::ADTypes.AutoForwardDiff{C}, ℓ) where {C}
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ) where {C}
     if C === nothing
         # Use default chunk size
-        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ)
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; tag = ad.tag)
     else
-        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; chunk = C)
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; chunk = C, tag = ad.tag)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,7 +173,8 @@ end
     @test ADgradient(:ForwardDiff, ℓ; chunk = 3) isa eltype(∇ℓ)
 
     # ADTypes support
-    @test ADgradient(ADTypes.AutoForwardDiff(3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunsize = 3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunsize = 3, tag = TestTag()), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3, tag = TestTag())
 end
 
 @testset "component vectors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,8 +173,8 @@ end
     @test ADgradient(:ForwardDiff, ℓ; chunk = 3) isa eltype(∇ℓ)
 
     # ADTypes support
-    @test ADgradient(ADTypes.AutoForwardDiff(; chunsize = 3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
-    @test ADgradient(ADTypes.AutoForwardDiff(; chunsize = 3, tag = TestTag()), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3, tag = TestTag())
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize = 3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize = 3, tag = TestTag()), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3, tag = TestTag())
 end
 
 @testset "component vectors" begin


### PR DESCRIPTION
This PR adds support for ADTypes 2. Unfortunately, CompatHelper does not support weak dependencies yet (https://github.com/JuliaRegistries/CompatHelper.jl/issues/452) but apparently there is a PR that would fix this (https://github.com/JuliaRegistries/CompatHelper.jl/pull/458).

Edit: Seems that ADTypes 1.7 broke our tests (positional argument was switched to a keyword argument, consistent with other AD types). Additionally, I added support for AutoForwardDiff tags which was also added in ADTypes 1.7.