### PR TITLE
Widen Enzyme compat to avoid transitive dependency conflict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ LogDensityProblemsADZygoteExt = "Zygote"
 [compat]
 ADTypes = "0.1.7, 0.2"
 DocStringExtensions = "0.8, 0.9"
-Enzyme = "0.11"
+Enzyme = "0.11, 0.12"
 FiniteDifferences = "0.12"
 LogDensityProblems = "1, 2"
 Requires = "0.5, 1"


### PR DESCRIPTION
The recent 0.12 release of Enzyme caused a conflict for me with Turing, which is resolved by annoyingly downgrading this package until there are no more compat bounds.
The tests pass for me with version 0.12, so hopefully it is safe to allow it as well.