### PR TITLE
Fix AutoReverseDiff deprecation warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.9.0"
+version = "1.9.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -30,7 +30,7 @@ LogDensityProblemsADTrackerExt = "Tracker"
 LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
-ADTypes = "0.1.7, 0.2, 1"
+ADTypes = "1.5"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11, 0.12"
 FiniteDifferences = "0.12"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -37,8 +37,8 @@ function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ) wh
     end
 end
 
-function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff, ℓ)
-    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(ad.compile))
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
+    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
 end
 
 function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,7 +81,7 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag, V}}, ::Base.Fix1{typeof(log
 
     # ADTypes support
     @test ADgradient(ADTypes.AutoReverseDiff(), ℓ) === ∇ℓ_default
-    @test ADgradient(ADTypes.AutoReverseDiff(; compile = false), ℓ) === ∇ℓ_nocompile
+    @test ADgradient(ADTypes.AutoReverseDiff(; compile = Val(false)), ℓ) === ∇ℓ_nocompile
 
     ∇ℓ_compile = ADgradient(:ReverseDiff, ℓ; compile=Val(true))
     ∇ℓ_compile_x = ADgradient(:ReverseDiff, ℓ; compile=Val(true), x=rand(3))
@@ -90,7 +90,7 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag, V}}, ::Base.Fix1{typeof(log
     end
 
     # ADTypes support
-    @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = true), ℓ)) === typeof(∇ℓ_compile)
+    @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ)) === typeof(∇ℓ_compile)
 
     for ∇ℓ in (∇ℓ_default, ∇ℓ_nocompile, ∇ℓ_compile, ∇ℓ_compile_x)
         @test dimension(∇ℓ) == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ import ADTypes # load support for AD types with options
 import BenchmarkTools                            # load the heuristic chunks code
 using ComponentArrays: ComponentVector           # test with other vector types
 
-struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI} end
+struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI, false} end
 
 ####
 #### test setup and utilities


### PR DESCRIPTION
Fixes a deprecation warning by switching to the new form of the constructor and the type parameter of `ADTypes.AutoReverseDiff` introduced in ADTypes 1.5.

Ref https://github.com/TuringLang/Turing.jl/issues/2302