### PR TITLE
Add back support for ADTypes < 1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.9.1"
+version = "1.9.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -37,8 +37,18 @@ function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ) wh
     end
 end
 
-function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
-    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
+# ADTypes 1.5 introduced a type parameter for `AutoReverseDiff` and deprecated the
+# `compile` field
+# Since Julia < 1.9 uses Requires which does not respect the ADTypes compat entry,
+# we keep the version for ADTypes < 1.5 as well
+@static if ADTypes.AutoReverseDiff isa UnionAll
+    function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
+        return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
+    end
+else
+    function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff, ℓ)
+        return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(ad.compile))
+    end
 end
 
 function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ)


### PR DESCRIPTION
#34 broke ADTypes support on older Julia versions since the Requires-based loading does not respect compat entries: https://github.com/TuringLang/Turing.jl/issues/2305#issuecomment-2288399653

The better long-term solution might be to drop support for Julia < 1.9 or make ADTypes a proper dependency on Julia < 1.9 (problems with AD backends might still pop up), but the PR is just intended as a quick hotfix.