### PR TITLE
Drop support for Julia < 1.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # Replace this with the minimum Julia version that your package supports. 
+          - '1.9' # Replace this with the minimum Julia version that your package supports. 
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.9.2"
+version = "1.10.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 
 [weakdeps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -31,13 +29,16 @@ LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
 ADTypes = "1.5"
+BenchmarkTools = "1"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11, 0.12"
 FiniteDifferences = "0.12"
+ForwardDiff = "0.10"
 LogDensityProblems = "1, 2"
-Requires = "0.5, 1"
-SimpleUnPack = "1"
-julia = "1.6"
+ReverseDiff = "1"
+Tracker = "0.2"
+Zygote = "0.6"
+julia = "1.9"
 
 [extras]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -37,18 +37,8 @@ function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ) wh
     end
 end
 
-# ADTypes 1.5 introduced a type parameter for `AutoReverseDiff` and deprecated the
-# `compile` field
-# Since Julia < 1.9 uses Requires which does not respect the ADTypes compat entry,
-# we keep the version for ADTypes < 1.5 as well
-@static if ADTypes.AutoReverseDiff isa UnionAll
-    function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
-        return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
-    end
-else
-    function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff, ℓ)
-        return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(ad.compile))
-    end
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
+    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
 end
 
 function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ)

--- a/ext/LogDensityProblemsADEnzymeExt.jl
+++ b/ext/LogDensityProblemsADEnzymeExt.jl
@@ -5,13 +5,11 @@ module LogDensityProblemsADEnzymeExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import Enzyme
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Enzyme
@@ -58,7 +56,7 @@ end
 
 function logdensity_and_gradient(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ForwardMode},
                                  x::AbstractVector)
-    @unpack ℓ, mode, shadow = ∇ℓ
+    (; ℓ, mode, shadow) = ∇ℓ
     _shadow = shadow === nothing ? Enzyme.onehot(x) : shadow
     y, ∂ℓ_∂x = Enzyme.autodiff(mode, logdensity, Enzyme.BatchDuplicated,
                                Enzyme.Const(ℓ),
@@ -68,7 +66,7 @@ end
 
 function logdensity_and_gradient(∇ℓ::EnzymeGradientLogDensity{<:Any,<:Enzyme.ReverseMode},
                                  x::AbstractVector)
-    @unpack ℓ = ∇ℓ
+    (; ℓ) = ∇ℓ
     ∂ℓ_∂x = zero(x)
     _, y = Enzyme.autodiff(Enzyme.ReverseWithPrimal, logdensity, Enzyme.Active,
                            Enzyme.Const(ℓ), Enzyme.Duplicated(x, ∂ℓ_∂x))

--- a/ext/LogDensityProblemsADFiniteDifferencesExt.jl
+++ b/ext/LogDensityProblemsADFiniteDifferencesExt.jl
@@ -5,13 +5,11 @@ module LogDensityProblemsADFiniteDifferencesExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import FiniteDifferences
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..FiniteDifferences
@@ -42,7 +40,7 @@ function Base.show(io::IO, ∇ℓ::FiniteDifferencesGradientLogDensity)
 end
 
 function logdensity_and_gradient(∇ℓ::FiniteDifferencesGradientLogDensity, x::AbstractVector)
-    @unpack ℓ, fdm = ∇ℓ
+    (; ℓ, fdm) = ∇ℓ
     y = logdensity(ℓ, x)
     ∇y = only(FiniteDifferences.grad(fdm, Base.Fix1(logdensity, ℓ), x))
     y, ∇y

--- a/ext/LogDensityProblemsADForwardDiffExt.jl
+++ b/ext/LogDensityProblemsADForwardDiffExt.jl
@@ -5,14 +5,12 @@ module LogDensityProblemsADForwardDiffExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ForwardDiff
     import ForwardDiff: DiffResults
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..ForwardDiff
@@ -45,7 +43,7 @@ _ensure_chunk(chunk::Integer) = ForwardDiff.Chunk(chunk)
 _default_chunk(ℓ) = _ensure_chunk(dimension(ℓ))
 
 function Base.copy(fℓ::ForwardDiffLogDensity{L,C,T,<:ForwardDiff.GradientConfig}) where {L,C,T}
-    @unpack ℓ, chunk, tag, gradient_config = fℓ
+    (; ℓ, chunk, tag, gradient_config) = fℓ
     ForwardDiffLogDensity(ℓ, chunk, tag, copy(gradient_config))
 end
 
@@ -109,7 +107,7 @@ function ADgradient(::Val{:ForwardDiff}, ℓ;
 end
 
 function logdensity_and_gradient(fℓ::ForwardDiffLogDensity, x::AbstractVector)
-    @unpack ℓ, chunk, tag, gradient_config = fℓ
+    (; ℓ, chunk, tag, gradient_config) = fℓ
     buffer = _diffresults_buffer(x)
     ℓ′ = Base.Fix1(logdensity, ℓ)
     if gradient_config ≡ nothing

--- a/ext/LogDensityProblemsADReverseDiffExt.jl
+++ b/ext/LogDensityProblemsADReverseDiffExt.jl
@@ -5,14 +5,12 @@ module LogDensityProblemsADReverseDiffExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ReverseDiff
     import ReverseDiff: DiffResults
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, SIGNATURES, dimension, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..ReverseDiff
@@ -66,7 +64,7 @@ function Base.show(io::IO, ∇ℓ::ReverseDiffLogDensity)
 end
 
 function logdensity_and_gradient(∇ℓ::ReverseDiffLogDensity, x::AbstractVector)
-    @unpack ℓ, compiledtape = ∇ℓ
+    (; ℓ, compiledtape) = ∇ℓ
     buffer = _diffresults_buffer(x)
     if compiledtape === nothing
         result = ReverseDiff.gradient!(buffer, Base.Fix1(logdensity, ℓ), x)

--- a/ext/LogDensityProblemsADTrackerExt.jl
+++ b/ext/LogDensityProblemsADTrackerExt.jl
@@ -5,13 +5,11 @@ module LogDensityProblemsADTrackerExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import Tracker
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Tracker
@@ -34,7 +32,7 @@ ADgradient(::Val{:Tracker}, ℓ) = TrackerGradientLogDensity(ℓ)
 Base.show(io::IO, ∇ℓ::TrackerGradientLogDensity) = print(io, "Tracker AD wrapper for ", ∇ℓ.ℓ)
 
 function logdensity_and_gradient(∇ℓ::TrackerGradientLogDensity, x::AbstractVector{T}) where {T}
-    @unpack ℓ = ∇ℓ
+    (; ℓ) = ∇ℓ
     y, back = Tracker.forward(x -> logdensity(ℓ, x), x)
     yval = Tracker.data(y)
     # work around https://github.com/FluxML/Flux.jl/issues/497

--- a/ext/LogDensityProblemsADZygoteExt.jl
+++ b/ext/LogDensityProblemsADZygoteExt.jl
@@ -5,13 +5,11 @@ module LogDensityProblemsADZygoteExt
 
 if isdefined(Base, :get_extension)
     using LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using LogDensityProblemsAD.SimpleUnPack: @unpack
     
     import LogDensityProblemsAD: ADgradient, logdensity_and_gradient    
     import Zygote
 else
     using ..LogDensityProblemsAD: ADGradientWrapper, logdensity
-    using ..LogDensityProblemsAD.SimpleUnPack: @unpack
 
     import ..LogDensityProblemsAD: ADgradient, logdensity_and_gradient
     import ..Zygote
@@ -32,7 +30,7 @@ ADgradient(::Val{:Zygote}, ℓ) = ZygoteGradientLogDensity(ℓ)
 Base.show(io::IO, ∇ℓ::ZygoteGradientLogDensity) = print(io, "Zygote AD wrapper for ", ∇ℓ.ℓ)
 
 function logdensity_and_gradient(∇ℓ::ZygoteGradientLogDensity, x::AbstractVector)
-    @unpack ℓ = ∇ℓ
+    (; ℓ) = ∇ℓ
     y, back = Zygote.pullback(Base.Fix1(logdensity, ℓ), x)
     y, first(back(Zygote.sensitivity(y)))
 end

--- a/src/LogDensityProblemsAD.jl
+++ b/src/LogDensityProblemsAD.jl
@@ -9,8 +9,6 @@ using DocStringExtensions: SIGNATURES
 import LogDensityProblems: logdensity, logdensity_and_gradient, capabilities, dimension
 using LogDensityProblems: LogDensityOrder
 
-import SimpleUnPack
-
 #####
 ##### AD wrappers --- interface and generic code
 #####
@@ -75,28 +73,5 @@ end
 #####
 function benchmark_ForwardDiff_chunks end
 function heuristic_chunks end
-
-# Backward compatible AD wrappers on Julia versions that do not support extensions
-# TODO: Replace with proper version
-const EXTENSIONS_SUPPORTED = isdefined(Base, :get_extension)
-if !EXTENSIONS_SUPPORTED
-    using Requires: @require
-end
-@static if !EXTENSIONS_SUPPORTED
-    function __init__()
-        @require ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b" include("../ext/LogDensityProblemsADADTypesExt.jl")
-        @require FiniteDifferences="26cc04aa-876d-5657-8c51-4c34ba976000" include("../ext/LogDensityProblemsADFiniteDifferencesExt.jl")
-        @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
-            include("../ext/LogDensityProblemsADForwardDiffExt.jl")
-            @require BenchmarkTools="6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf" begin
-                include("../ext/LogDensityProblemsADForwardDiffBenchmarkToolsExt.jl")
-            end
-        end
-        @require Tracker="9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" include("../ext/LogDensityProblemsADTrackerExt.jl")
-        @require Zygote="e88e6eb3-aa80-5325-afca-941959d7151f" include("../ext/LogDensityProblemsADZygoteExt.jl")
-        @require ReverseDiff="37e2e3b7-166d-5795-8a7a-e32c996b4267" include("../ext/LogDensityProblemsADReverseDiffExt.jl")
-        @require Enzyme="7da242da-08ed-463a-9acd-ee780be4f1d9" include("../ext/LogDensityProblemsADEnzymeExt.jl")
-    end
-end
 
 end # module


### PR DESCRIPTION
The PR drops support for Julia < 1.9 since Requires does not respect compat entries (see #35). I also added missing compat entries and removed SimpleUnPack (on Julia >= 1.7 it uses the native destructuring syntax anyway).