### PR TITLE
Use DI for non-implemented ADTypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 [weakdeps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -19,6 +20,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
 LogDensityProblemsADADTypesExt = "ADTypes"
+LogDensityProblemsADDifferentiationInterfaceExt = ["ADTypes", "DifferentiationInterface"]
 LogDensityProblemsADEnzymeExt = "Enzyme"
 LogDensityProblemsADFiniteDifferencesExt = "FiniteDifferences"
 LogDensityProblemsADForwardDiffBenchmarkToolsExt = ["BenchmarkTools", "ForwardDiff"]
@@ -29,6 +31,7 @@ LogDensityProblemsADZygoteExt = "Zygote"
 
 [compat]
 ADTypes = "1.5"
+DifferentiationInterface = "0.6.1"
 BenchmarkTools = "1"
 DocStringExtensions = "0.8, 0.9"
 Enzyme = "0.11, 0.12, 0.13"
@@ -44,6 +47,7 @@ julia = "1.9"
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -54,4 +58,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "BenchmarkTools", "ComponentArrays", "Enzyme", "FiniteDifferences", "ForwardDiff", "Random", "ReverseDiff", "Test", "Tracker", "Zygote"]
+test = ["ADTypes", "BenchmarkTools", "ComponentArrays", "DifferentiationInterface", "Enzyme", "FiniteDifferences", "ForwardDiff", "Random", "ReverseDiff", "Test", "Tracker", "Zygote"]

--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ x = zeros(LogDensityProblems.dimension(ℓ)) # ℓ is your log density
     
 5. [FiniteDifferences.jl](https://github.com/JuliaDiff/FiniteDifferences.jl) Finite differences are very robust, with a small numerical error, but usually not fast enough to practically replace AD on nontrivial problems. The backend in this package is mainly intended for checking and debugging results from other backends; but note that in most cases ForwardDiff is faster and more accurate.
 
-PRs for other AD frameworks are welcome, even if they are WIP.
+Other AD frameworks are supported thanks to [ADTypes.jl](https://github.com/SciML/ADTypes.jl) and [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl).
+
+PRs for remaining AD frameworks are welcome, even if they are WIP.

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -29,6 +29,9 @@ If you want to use another backend from [ADTypes.jl](https://github.com/SciML/AD
 LogDensityProblemsAD.ADgradient(::ADTypes.AbstractADType, ℓ)
 
 function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoEnzyme, ℓ; x::Union{Nothing,AbstractVector}=nothing)
+    if x !== nothing  
+        @warn "`ADgradient`: Keyword argument `x` is ignored"  
+    end
     if ad.mode === nothing
         # Use default mode (Enzyme.Reverse)
         return LogDensityProblemsAD.ADgradient(Val(:Enzyme), ℓ)
@@ -51,11 +54,17 @@ function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ; x:
 end
 
 function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ; x::Union{Nothing,AbstractVector}=nothing)
+    if x !== nothing  
+        @warn "`ADgradient`: Keyword argument `x` is ignored"  
+    end
     return LogDensityProblemsAD.ADgradient(Val(:Tracker), ℓ)
 end
 
 
 function LogDensityProblemsAD.ADgradient(::ADTypes.AutoZygote, ℓ; x::Union{Nothing,AbstractVector}=nothing)
+    if x !== nothing  
+        @warn "`ADgradient`: Keyword argument `x` is ignored"  
+    end
     return LogDensityProblemsAD.ADgradient(Val(:Zygote), ℓ)
 end
 

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -22,7 +22,7 @@ Currently,
 are supported with custom implementations.
 The AD configuration specified by `ad` is forwarded to the corresponding calls of `ADgradient(Val(...), ℓ)`.
 
-Passing `x` as a keyword argument means that the gradient operator will be "prepared" for the specific type and size of the array `x`. This can speed up further evaluations on similar inputs, but will likely cause errors if the new inputs have a different type or size. With ReverseDiff, it can also yield incorrect results if the logdensity contains value-dependent control flow.
+Passing `x` as a keyword argument means that the gradient operator will be "prepared" for the specific type and size of the array `x`. This can speed up further evaluations on similar inputs, but will likely cause errors if the new inputs have a different type or size. With `AutoReverseDiff`, it can also yield incorrect results if the logdensity contains value-dependent control flow.
 
 !!! warning
     If you want to use another backend from ADTypes which is not in the list above, or if you want to provide `x` for preparation, you need to load [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl) first.

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -24,13 +24,11 @@ The AD configuration specified by `ad` is forwarded to the corresponding calls o
 
 Passing `x` as a keyword argument means that the gradient operator will be "prepared" for the specific type and size of the array `x`. This can speed up further evaluations on similar inputs, but will likely cause errors if the new inputs have a different type or size. With `AutoReverseDiff`, it can also yield incorrect results if the logdensity contains value-dependent control flow.
 
-!!! warning
-    If you want to use another backend from ADTypes which is not in the list above, or if you want to provide `x` for preparation, you need to load [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl) first.
-    See the documentation of that package, especially `DifferentiationInterface.prepare_gradient`, for more details on preparation.
+If you want to use another backend from [ADTypes.jl](https://github.com/SciML/ADTypes.jl) which is not in the list above, you need to load [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl) first.
 """
 LogDensityProblemsAD.ADgradient(::ADTypes.AbstractADType, ℓ)
 
-function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoEnzyme, ℓ)
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoEnzyme, ℓ; x::Union{Nothing,AbstractVector}=nothing)
     if ad.mode === nothing
         # Use default mode (Enzyme.Reverse)
         return LogDensityProblemsAD.ADgradient(Val(:Enzyme), ℓ)
@@ -39,25 +37,25 @@ function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoEnzyme, ℓ)
     end
 end
 
-function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ) where {C}
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoForwardDiff{C}, ℓ; x::Union{Nothing,AbstractVector}=nothing) where {C}
     if C === nothing
         # Use default chunk size
-        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; tag = ad.tag)
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; tag = ad.tag, x=x)
     else
-        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; chunk = C, tag = ad.tag)
+        return LogDensityProblemsAD.ADgradient(Val(:ForwardDiff), ℓ; chunk = C, tag = ad.tag, x=x)
     end
 end
 
-function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ) where {T}
-    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T))
+function LogDensityProblemsAD.ADgradient(ad::ADTypes.AutoReverseDiff{T}, ℓ; x::Union{Nothing,AbstractVector}=nothing) where {T}
+    return LogDensityProblemsAD.ADgradient(Val(:ReverseDiff), ℓ; compile = Val(T), x=x)
 end
 
-function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ)
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoTracker, ℓ; x::Union{Nothing,AbstractVector}=nothing)
     return LogDensityProblemsAD.ADgradient(Val(:Tracker), ℓ)
 end
 
 
-function LogDensityProblemsAD.ADgradient(::ADTypes.AutoZygote, ℓ)
+function LogDensityProblemsAD.ADgradient(::ADTypes.AutoZygote, ℓ; x::Union{Nothing,AbstractVector}=nothing)
     return LogDensityProblemsAD.ADgradient(Val(:Zygote), ℓ)
 end
 

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -20,10 +20,13 @@ Currently,
 - `ad::ADTypes.AutoTracker`
 - `ad::ADTypes.AutoZygote`
 are supported with custom implementations.
-The AD configuration specified by `ad` is forwarded to the corresponding calls of `ADgradient(Val(...), ℓ)`.    
+The AD configuration specified by `ad` is forwarded to the corresponding calls of `ADgradient(Val(...), ℓ)`.
+
+Passing `x` as a keyword argument means that the gradient operator will be "prepared" for the specific type and size of the array `x`. This can speed up further evaluations on similar inputs, but will likely cause errors if the new inputs have a different type or size. With ReverseDiff, it can also yield incorrect results if the logdensity contains value-dependent control flow.
 
 !!! warning
-    If you want to use another backend from ADTypes which is not in the list above, or if you want to provide `x` as a keyword argument, you need to load DifferentiationInterface first.
+    If you want to use another backend from ADTypes which is not in the list above, or if you want to provide `x` for preparation, you need to load [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl) first.
+    See the documentation of that package, especially `DifferentiationInterface.prepare_gradient`, for more details on preparation.
 """
 LogDensityProblemsAD.ADgradient(::ADTypes.AbstractADType, ℓ)
 

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -9,7 +9,7 @@ else
 end
 
 """
-    ADgradient(ad::ADTypes.AbstractADType, ℓ)
+    ADgradient(ad::ADTypes.AbstractADType, ℓ; x=nothing)
 
 Wrap log density `ℓ` using automatic differentiation (AD) of type `ad` to obtain a gradient.
 
@@ -19,8 +19,11 @@ Currently,
 - `ad::ADTypes.AutoReverseDiff`
 - `ad::ADTypes.AutoTracker`
 - `ad::ADTypes.AutoZygote`
-are supported.
+are supported with custom implementations.
 The AD configuration specified by `ad` is forwarded to the corresponding calls of `ADgradient(Val(...), ℓ)`.    
+
+!!! warning
+    If you want to use another backend from ADTypes which is not in the list above, or if you want to provide `x` as a keyword argument, you need to load DifferentiationInterface first.
 """
 LogDensityProblemsAD.ADgradient(::ADTypes.AbstractADType, ℓ)
 

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -9,7 +9,7 @@ else
 end
 
 """
-    ADgradient(ad::ADTypes.AbstractADType, ℓ; x=nothing)
+    ADgradient(ad::ADTypes.AbstractADType, ℓ; x::Union{Nothing,AbstractVector}=nothing)
 
 Wrap log density `ℓ` using automatic differentiation (AD) of type `ad` to obtain a gradient.
 

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -10,7 +10,18 @@ else
     import ..DifferentiationInterface as DI
 end
 
-struct DIGradient{B,P,L} <: LogDensityProblemsAD.ADGradientWrapper
+"""
+    DIGradient <: LogDensityProblemsAD.ADGradientWrapper
+
+Gradient wrapper which uses [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl)
+
+# Fields
+
+- `backend::AbstractADType`: one of the autodiff backend types defined in [ADTypes.jl](https://github.com/SciML/ADTypes.jl), for example `ADTypes.AutoForwardDiff()`
+- `prep`: either `nothing` or the output of `DifferentiationInterface.prepare_gradient` applied to the logdensity and the provided input
+- `ℓ`: logdensity function, amenable to `LogDensityProblemsAD.logdensity(ℓ, x)`
+"""
+struct DIGradient{B<:AbstractADType,P,L} <: LogDensityProblemsAD.ADGradientWrapper
     backend::B
     prep::P
     ℓ::L

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -1,0 +1,42 @@
+module LogDensityProblemsADDifferentiationInterfaceExt
+
+if isdefined(Base, :get_extension)
+    import LogDensityProblemsAD
+    import ADTypes
+    import DifferentiationInterface as DI
+else
+    import ..LogDensityProblemsAD
+    import ..ADTypes
+    import ..DifferentiationInterface as DI
+end
+
+struct DIGradient{B,P,L} <: LogDensityProblemsAD.ADGradientWrapper
+    backend::B
+    prep::P
+    ℓ::L
+end
+
+function logdensity_switched(x, ℓ)
+    # active argument must come first in DI
+    return LogDensityProblemsAD.logdensity(ℓ, x)
+end
+
+function LogDensityProblemsAD.ADgradient(backend::ADTypes.AbstractADType, ℓ; x=nothing)
+    if isnothing(x)
+        prep = nothing
+    else
+        prep = DI.prepare_gradient(logdensity_switched, backend, x, DI.Constant(ℓ))
+    end
+    return DIGradient(backend, prep, ℓ)
+end
+
+function LogDensityProblemsAD.logdensity_and_gradient(∇ℓ::DIGradient, x)
+    backend, prep, ℓ = ∇ℓ.backend, ∇ℓ.prep, ∇ℓ.ℓ
+    if isnothing(prep)
+        return DI.value_and_gradient(logdensity_switched, backend, x, DI.Constant(ℓ))
+    else
+        return DI.value_and_gradient(logdensity_switched, prep, backend, x, DI.Constant(ℓ))
+    end
+end
+
+end

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -21,7 +21,7 @@ Gradient wrapper which uses [DifferentiationInterface.jl](https://github.com/gda
 - `prep`: either `nothing` or the output of `DifferentiationInterface.prepare_gradient` applied to the logdensity and the provided input
 - `ℓ`: logdensity function, amenable to `LogDensityProblemsAD.logdensity(ℓ, x)`
 """
-struct DIGradient{B<:AbstractADType,P,L} <: LogDensityProblemsAD.ADGradientWrapper
+struct DIGradient{B<:ADTypes.AbstractADType,P,L} <: LogDensityProblemsAD.ADGradientWrapper
     backend::B
     prep::P
     ℓ::L

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -1,14 +1,8 @@
 module LogDensityProblemsADDifferentiationInterfaceExt
 
-if isdefined(Base, :get_extension)
-    import LogDensityProblemsAD
-    import ADTypes
-    import DifferentiationInterface as DI
-else
-    import ..LogDensityProblemsAD
-    import ..ADTypes
-    import ..DifferentiationInterface as DI
-end
+import LogDensityProblemsAD
+import ADTypes
+import DifferentiationInterface as DI
 
 """
     DIGradient <: LogDensityProblemsAD.ADGradientWrapper

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -42,7 +42,7 @@ function LogDensityProblemsAD.ADgradient(backend::ADTypes.AbstractADType, ℓ; x
 end
 
 function LogDensityProblemsAD.logdensity_and_gradient(∇ℓ::DIGradient, x)
-    backend, prep, ℓ = ∇ℓ.backend, ∇ℓ.prep, ∇ℓ.ℓ
+    (; backend, prep, ℓ) = ∇ℓ
     if isnothing(prep)
         return DI.value_and_gradient(logdensity_switched, backend, x, DI.Constant(ℓ))
     else

--- a/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
+++ b/ext/LogDensityProblemsADDifferentiationInterfaceExt.jl
@@ -26,8 +26,8 @@ function logdensity_switched(x, ℓ)
     return LogDensityProblemsAD.logdensity(ℓ, x)
 end
 
-function LogDensityProblemsAD.ADgradient(backend::ADTypes.AbstractADType, ℓ; x=nothing)
-    if isnothing(x)
+function LogDensityProblemsAD.ADgradient(backend::ADTypes.AbstractADType, ℓ; x::Union{Nothing,AbstractVector}=nothing)
+    if x === nothing
         prep = nothing
     else
         prep = DI.prepare_gradient(logdensity_switched, backend, x, DI.Constant(ℓ))
@@ -35,9 +35,9 @@ function LogDensityProblemsAD.ADgradient(backend::ADTypes.AbstractADType, ℓ; x
     return DIGradient(backend, prep, ℓ)
 end
 
-function LogDensityProblemsAD.logdensity_and_gradient(∇ℓ::DIGradient, x)
+function LogDensityProblemsAD.logdensity_and_gradient(∇ℓ::DIGradient, x::AbstractVector)
     (; backend, prep, ℓ) = ∇ℓ
-    if isnothing(prep)
+    if prep === nothing
         return DI.value_and_gradient(logdensity_switched, backend, x, DI.Constant(ℓ))
     else
         return DI.value_and_gradient(logdensity_switched, prep, backend, x, DI.Constant(ℓ))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag, V}}, ::Base.Fix1{typeof(log
     @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ)) === typeof(∇ℓ_compile)
     @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ; x=rand(3))) === typeof(∇ℓ_compile_x)
    @test nameof(typeof(ADgradient(ADTypes.AutoReverseDiff(), ℓ))) !== :DIGradient
-   @test nameof(typeof(ADgradient(ADTypes.AutoReverseDiff(), ℓ; x=rand(3))) !== :DIGradient
+   @test nameof(typeof(ADgradient(ADTypes.AutoReverseDiff(), ℓ; x=rand(3)))) !== :DIGradient
 
     for ∇ℓ in (∇ℓ_default, ∇ℓ_nocompile, ∇ℓ_compile, ∇ℓ_compile_x)
         @test dimension(∇ℓ) == 3
@@ -316,7 +316,7 @@ end
         push!(∇ℓ_candidates, ADgradient(backend, ℓ; x=zeros(3)))
     end
     @testset "$(typeof(∇ℓ))" for ∇ℓ in ∇ℓ_candidates
-        @test ∇ℓ isa DIGradient
+        @test nameof(typeof(∇ℓ)) == :DIGradient
         @test dimension(∇ℓ) == 3
         @test capabilities(∇ℓ) ≡ LogDensityOrder(1)
         for _ in 1:100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,6 @@ import BenchmarkTools                            # load the heuristic chunks cod
 using ComponentArrays: ComponentVector           # test with other vector types
 import DifferentiationInterface
 
-DIGradient = Base.get_extension(
-    LogDensityProblemsAD,
-    :LogDensityProblemsADDifferentiationInterfaceExt
-).DIGradient
-
 struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI, false, false} end
 
 ####
@@ -98,8 +93,8 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag, V}}, ::Base.Fix1{typeof(log
     # ADTypes support
     @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ)) === typeof(∇ℓ_compile)
     @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ; x=rand(3))) === typeof(∇ℓ_compile_x)
-   @test !isa(ADgradient(ADTypes.AutoReverseDiff(), ℓ), DIGradient)
-   @test !isa(ADgradient(ADTypes.AutoReverseDiff(), ℓ; x=rand(3)), DIGradient)
+   @test nameof(typeof(ADgradient(ADTypes.AutoReverseDiff(), ℓ))) !== :DIGradient
+   @test nameof(typeof(ADgradient(ADTypes.AutoReverseDiff(), ℓ; x=rand(3))) !== :DIGradient
 
     for ∇ℓ in (∇ℓ_default, ∇ℓ_nocompile, ∇ℓ_compile, ∇ℓ_compile_x)
         @test dimension(∇ℓ) == 3
@@ -136,8 +131,8 @@ end
 
     # ADTypes support
     @test ADgradient(ADTypes.AutoForwardDiff(), ℓ) === ∇ℓ
-    @test !isa(ADgradient(ADTypes.AutoForwardDiff(), ℓ), DIGradient)
-    @test !isa(ADgradient(ADTypes.AutoForwardDiff(), ℓ; x=rand(3)), DIGradient)
+    @test nameof(typeof(ADgradient(ADTypes.AutoForwardDiff(), ℓ))) !== :DIGradient
+    @test nameof(typeof(ADgradient(ADTypes.AutoForwardDiff(), ℓ; x=rand(3)))) !== :DIGradient
 
     for _ in 1:100
         x = randn(3)
@@ -223,8 +218,8 @@ end
 
    # ADTypes support
    @test ADgradient(ADTypes.AutoTracker(), ℓ) === ∇ℓ
-   @test !isa(ADgradient(ADTypes.AutoTracker(), ℓ), DIGradient)
-   @test !isa(ADgradient(ADTypes.AutoTracker(), ℓ; x=rand(3)), DIGradient)
+   @test nameof(typeof(ADgradient(ADTypes.AutoTracker(), ℓ))) !== :DIGradient
+   @test nameof(typeof(ADgradient(ADTypes.AutoTracker(), ℓ; x=rand(3)))) !== :DIGradient
 end
 
 @testset "AD via Zygote" begin
@@ -241,8 +236,8 @@ end
 
    # ADTypes support
    @test ADgradient(ADTypes.AutoZygote(), ℓ) === ∇ℓ
-   @test !isa(ADgradient(ADTypes.AutoZygote(), ℓ), DIGradient)
-   @test !isa(ADgradient(ADTypes.AutoZygote(), ℓ; x=rand(3)), DIGradient)
+   @test nameof(typeof(ADgradient(ADTypes.AutoZygote(), ℓ))) !== :DIGradient
+   @test nameof(typeof(ADgradient(ADTypes.AutoZygote(), ℓ; x=rand(3)))) !== :DIGradient
 end
 
 @testset "AD via Enzyme" begin
@@ -257,8 +252,8 @@ end
 
     # ADTypes support
     @test ADgradient(ADTypes.AutoEnzyme(), ℓ) === ∇ℓ_reverse
-    @test !isa(ADgradient(ADTypes.AutoEnzyme(), ℓ), DIGradient)
-    @test !isa(ADgradient(ADTypes.AutoEnzyme(), ℓ; x=rand(3)), DIGradient)
+    @test nameof(typeof(ADgradient(ADTypes.AutoEnzyme(), ℓ))) !== :DIGradient
+    @test nameof(typeof(ADgradient(ADTypes.AutoEnzyme(), ℓ; x=rand(3)))) !== :DIGradient
 
     ∇ℓ_forward = ADgradient(:Enzyme, ℓ; mode=Enzyme.Forward)
     @test ADgradient(ADTypes.AutoEnzyme(;mode=Enzyme.Forward), ℓ) === ∇ℓ_forward

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,15 +290,15 @@ end
 
 @testset "DifferentiationInterface for unsupported ADTypes" begin
     # FiniteDifferences is not part of the extension that converts ADTypes to symbols
-    backend = ADTypes.AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1))
+    backend = ADTypes.AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(5, 1))
     ℓ = TestLogDensity(test_logdensity1)
     for ∇ℓ in (ADgradient(backend, ℓ), ADgradient(backend, ℓ; x=zeros(3)))
         @test dimension(∇ℓ) == 3
         @test capabilities(∇ℓ) ≡ LogDensityOrder(1)
         for _ in 1:100
             x = randn(3)
-            @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity1(x) atol = 1e-4
-            @test logdensity_and_gradient(∇ℓ, x) ≅ (test_logdensity1(x), test_gradient(x)) atol = 1e-4
+            @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity1(x)
+            @test logdensity_and_gradient(∇ℓ, x) ≅ (test_logdensity1(x), test_gradient(x)) atol = 1e-5
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ import BenchmarkTools                            # load the heuristic chunks cod
 using ComponentArrays: ComponentVector           # test with other vector types
 import DifferentiationInterface
 
-struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI,false} end
+struct EnzymeTestMode <: Enzyme.Mode{Enzyme.DefaultABI, false} end
 
 ####
 #### test setup and utilities
@@ -29,9 +29,9 @@ Random.seed!(1)
 
 Compare log denfields and types, for unit testing.
 """
-≅(::Any, ::Any; atol=0) = false
+≅(::Any, ::Any; atol = 0) = false
 
-function ≅(a::Real, b::Real; atol=0)
+function ≅(a::Real, b::Real; atol = 0)
     if isnan(a)
         isnan(b)
     elseif isinf(a)
@@ -41,9 +41,9 @@ function ≅(a::Real, b::Real; atol=0)
     end
 end
 
-function ≅(a::Tuple{Real,Any}, b::Tuple{Real,Any}; atol=0)
-    ≅(first(a), first(b); atol=atol) || return false
-    !isfinite(first(a)) || isapprox(last(a), last(b); atol=atol, rtol=0)
+function ≅(a::Tuple{Real,Any}, b::Tuple{Real,Any}; atol = 0)
+    ≅(first(a), first(b); atol = atol) || return false
+    !isfinite(first(a)) || isapprox(last(a), last(b); atol = atol, rtol = 0)
 end
 
 ###
@@ -69,7 +69,7 @@ dimension(::TestLogDensity2) = 20
 struct TestTag end
 
 # Allow tag type in gradient etc. calls of the log density function
-ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag,V}}, ::Base.Fix1{typeof(logdensity),typeof(TestLogDensity())}, ::AbstractArray{V}) where {V} = true
+ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag, V}}, ::Base.Fix1{typeof(logdensity),typeof(TestLogDensity())}, ::AbstractArray{V}) where {V} = true
 
 @testset "AD via ReverseDiff" begin
     ℓ = TestLogDensity()
@@ -82,7 +82,7 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag,V}}, ::Base.Fix1{typeof(logd
 
     # ADTypes support
     @test ADgradient(ADTypes.AutoReverseDiff(), ℓ) === ∇ℓ_default
-    @test ADgradient(ADTypes.AutoReverseDiff(; compile=Val(false)), ℓ) === ∇ℓ_nocompile
+    @test ADgradient(ADTypes.AutoReverseDiff(; compile = Val(false)), ℓ) === ∇ℓ_nocompile
 
     ∇ℓ_compile = ADgradient(:ReverseDiff, ℓ; compile=Val(true))
     ∇ℓ_compile_x = ADgradient(:ReverseDiff, ℓ; compile=Val(true), x=rand(3))
@@ -91,7 +91,7 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag,V}}, ::Base.Fix1{typeof(logd
     end
 
     # ADTypes support
-    @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile=Val(true)), ℓ)) === typeof(∇ℓ_compile)
+    @test typeof(ADgradient(ADTypes.AutoReverseDiff(; compile = Val(true)), ℓ)) === typeof(∇ℓ_compile)
 
     for ∇ℓ in (∇ℓ_default, ∇ℓ_nocompile, ∇ℓ_compile, ∇ℓ_compile_x)
         @test dimension(∇ℓ) == 3
@@ -101,18 +101,18 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TestTag,V}}, ::Base.Fix1{typeof(logd
             x = rand(3)
             @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
             @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-                  (test_logdensity(x), test_gradient(x))
+                (test_logdensity(x), test_gradient(x))
 
             x = -x
             @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
             if ∇ℓ.compiledtape === nothing
                 # Recompute tape => correct results
                 @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-                      (test_logdensity(x), zero(x))
+                    (test_logdensity(x), zero(x))
             else
                 # Tape not recomputed => incorrect results, uses always the same branch
                 @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-                      (test_logdensity1(x), test_gradient(x))
+                    (test_logdensity1(x), test_gradient(x))
             end
         end
     end
@@ -133,49 +133,49 @@ end
         x = randn(3)
         @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
         @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-              (test_logdensity(x), test_gradient(x))
+            (test_logdensity(x), test_gradient(x))
     end
 
     # custom tag
     for T in (Float32, Float64)
         x = randexp(T, 3)
         for tag in (ForwardDiff.Tag(TestTag(), T), TestTag())
-            local ∇ℓ = ADgradient(:ForwardDiff, ℓ; tag=tag)
+            local ∇ℓ = ADgradient(:ForwardDiff, ℓ; tag = tag)
             @test eltype(first(logdensity_and_gradient(∇ℓ, x))) === T
             @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
             @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-                  (test_logdensity(x), test_gradient(x))
+                (test_logdensity(x), test_gradient(x))
         end
     end
 
     # preallocated gradient config
     x = randexp(Float32, 3)
-    ∇ℓ = ADgradient(:ForwardDiff, ℓ; x=x)
+    ∇ℓ = ADgradient(:ForwardDiff, ℓ; x = x)
     @test eltype(first(logdensity_and_gradient(∇ℓ, x))) === Float32
     @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
     @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-          (test_logdensity(x), test_gradient(x))
+        (test_logdensity(x), test_gradient(x))
     @test @inferred(copy(∇ℓ)).gradient_config ≢ ∇ℓ.gradient_config
 
     # custom tag + preallocated gradient config
     for T in (Float32, Float64)
         x = randexp(T, 3)
         for tag in (ForwardDiff.Tag(TestTag(), T), TestTag())
-            ∇ℓ = ADgradient(:ForwardDiff, ℓ; tag=tag, x=x)
+            ∇ℓ = ADgradient(:ForwardDiff, ℓ; tag = tag, x = x)
             @test eltype(first(logdensity_and_gradient(∇ℓ, x))) === T
             @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
             @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅
-                  (test_logdensity(x), test_gradient(x))
+                (test_logdensity(x), test_gradient(x))
             @test @inferred(copy(∇ℓ)).gradient_config ≢ ∇ℓ.gradient_config
         end
     end
 
     # chunk size as integers
-    @test ADgradient(:ForwardDiff, ℓ; chunk=3) isa eltype(∇ℓ)
+    @test ADgradient(:ForwardDiff, ℓ; chunk = 3) isa eltype(∇ℓ)
 
     # ADTypes support
-    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize=3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk=3)
-    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize=3, tag=TestTag()), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk=3, tag=TestTag())
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize = 3), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3)
+    @test ADgradient(ADTypes.AutoForwardDiff(; chunksize = 3, tag = TestTag()), ℓ) === ADgradient(:ForwardDiff, ℓ; chunk = 3, tag = TestTag())
 end
 
 @testset "component vectors" begin
@@ -184,14 +184,14 @@ end
     ℓ = TestLogDensity()
     ∇ℓ = ADgradient(:ForwardDiff, ℓ)
     x = zeros(3)
-    y = ComponentVector(x=x)
+    y = ComponentVector(x = x)
     @test @inferred(logdensity(∇ℓ, y)) ≅ test_logdensity(x)
     @test @inferred(logdensity_and_gradient(∇ℓ, y)) ≅
-          (test_logdensity(x), test_gradient(x))
-    ∇ℓ2 = ADgradient(:ForwardDiff, ℓ; x=y) # preallocate GradientConfig
+        (test_logdensity(x), test_gradient(x))
+    ∇ℓ2 = ADgradient(:ForwardDiff, ℓ; x = y) # preallocate GradientConfig
     @test @inferred(logdensity(∇ℓ2, y)) ≅ test_logdensity(x)
     @test @inferred(logdensity_and_gradient(∇ℓ2, y)) ≅
-          (test_logdensity(x), test_gradient(x))
+        (test_logdensity(x), test_gradient(x))
 end
 
 @testset "chunk heuristics for ForwardDiff" begin
@@ -208,10 +208,10 @@ end
         x = randn(3)
         @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity(x)
         @test @inferred(logdensity_and_gradient(∇ℓ, x)) ≅ (test_logdensity(x), test_gradient(x))
-    end
+   end
 
-    # ADTypes support
-    @test ADgradient(ADTypes.AutoTracker(), ℓ) === ∇ℓ
+   # ADTypes support
+   @test ADgradient(ADTypes.AutoTracker(), ℓ) === ∇ℓ
 end
 
 @testset "AD via Zygote" begin
@@ -226,8 +226,8 @@ end
         @test logdensity_and_gradient(∇ℓ, x) ≅ (test_logdensity1(x), test_gradient(x))
     end
 
-    # ADTypes support
-    @test ADgradient(ADTypes.AutoZygote(), ℓ) === ∇ℓ
+   # ADTypes support
+   @test ADgradient(ADTypes.AutoZygote(), ℓ) === ∇ℓ
 end
 
 @testset "AD via Enzyme" begin
@@ -242,8 +242,8 @@ end
 
     ∇ℓ_forward = ADgradient(:Enzyme, ℓ; mode=Enzyme.Forward)
     ∇ℓ_forward_shadow = ADgradient(:Enzyme, ℓ;
-        mode=Enzyme.Forward,
-        shadow=Enzyme.onehot(Vector{Float64}(undef, dimension(ℓ))))
+                                   mode=Enzyme.Forward,
+                                   shadow=Enzyme.onehot(Vector{Float64}(undef, dimension(ℓ))))
     for ∇ℓ in (∇ℓ_forward, ∇ℓ_forward_shadow)
         @test repr(∇ℓ) == "Enzyme AD wrapper for " * repr(ℓ) * " with forward mode"
     end
@@ -260,7 +260,7 @@ end
 
     # Branches in `ADgradient`
     @test_throws ArgumentError ADgradient(:Enzyme, ℓ; mode=EnzymeTestMode())
-    ∇ℓ = @test_logs (:info, "keyword argument `shadow` is ignored in reverse mode") ADgradient(:Enzyme, ℓ; shadow=(1,))
+    ∇ℓ = @test_logs (:info, "keyword argument `shadow` is ignored in reverse mode") ADgradient(:Enzyme, ℓ; shadow = (1,))
     @test ∇ℓ.shadow === nothing
 end
 
@@ -273,7 +273,7 @@ end
     for _ in 1:100
         x = randn(3)
         @test @inferred(logdensity(∇ℓ, x)) ≅ test_logdensity1(x)
-        @test ≅(logdensity_and_gradient(∇ℓ, x), (test_logdensity1(x), test_gradient(x)); atol=1e-5)
+        @test ≅(logdensity_and_gradient(∇ℓ, x), (test_logdensity1(x), test_gradient(x)); atol = 1e-5)
     end
 end
 


### PR DESCRIPTION
This PR adds a teeny tiny extension for DifferentiationInterface (#26).
It can compute gradients for any `ADTypes.AbstractADType` that is not in the following list:
- `AutoEnzyme`
- `AutoForwardDiff`
- `AutoReverseDiff`
- `AutoTracker`
- `AutoZygote`

That way, your custom implementations remain the default, but for all other AD backends defined by ADTypes (and not symbols), DifferentiationInterface will kick in. This also allows you to gradually remove custom implementations in favor of DifferentiationInterface, if you so desire.

Ping @willtebbutt @torfjelde @adrhill

Note: since DI imposes Enzyme v0.13 in the tests, it may require merging #38 first.