### PR TITLE
Add error hints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LogDensityProblemsAD"
 uuid = "996a588d-648d-4e1f-a8f0-a84b347e47b1"
 authors = ["Tamás K. Papp <tkpapp@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -68,4 +68,15 @@ function LogDensityProblemsAD.ADgradient(::ADTypes.AutoZygote, ℓ; x::Union{Not
     return LogDensityProblemsAD.ADgradient(Val(:Zygote), ℓ)
 end
 
+# Better error message if users forget to load DifferentiationInterface
+if isdefined(Base.Experimental, :register_error_hint)
+    function __init__()
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
+            if exc.f === LogDensityProblemsAD.ADgradient && length(argtypes) == 2 && first(argtypes) <: ADTypes.AbstractADType
+                print(io, "\nDon't know how to AD with $(first(argtypes)). Did you forget to load DifferentiationInterface?")
+            end
+        end
+    end
+end
+
 end # module

--- a/ext/LogDensityProblemsADADTypesExt.jl
+++ b/ext/LogDensityProblemsADADTypesExt.jl
@@ -73,7 +73,7 @@ if isdefined(Base.Experimental, :register_error_hint)
     function __init__()
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
             if exc.f === LogDensityProblemsAD.ADgradient && length(argtypes) == 2 && first(argtypes) <: ADTypes.AbstractADType
-                print(io, "\nDon't know how to AD with $(first(argtypes)). Did you forget to load DifferentiationInterface?")
+                print(io, "\nDon't know how to AD with $(nameof(first(argtypes))). Did you forget to load DifferentiationInterface?")
             end
         end
     end

--- a/src/LogDensityProblemsAD.jl
+++ b/src/LogDensityProblemsAD.jl
@@ -65,11 +65,11 @@ ADgradient(kind::Symbol, P; kwargs...) = ADgradient(Val{kind}(), P; kwargs...)
 
 # Better error message if users forget to load the AD package
 if isdefined(Base.Experimental, :register_error_hint)
-    _extract_val(::Val{T}) where {T} = T
+    _unval(::Type{Val{T}}) where {T} = T
     function __init__()
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
             if exc.f === ADgradient && length(argtypes) == 2 && first(argtypes) <: Val
-                kind = _extract_val(first(argtypes))
+                kind = _unval(first(argtypes))
                 print(io, "\nDon't know how to AD with $(kind), consider `import $(kind)` if there is such a package.")
             end
         end

--- a/src/LogDensityProblemsAD.jl
+++ b/src/LogDensityProblemsAD.jl
@@ -63,9 +63,17 @@ The function `parent` can be used to retrieve the original argument.
 """
 ADgradient(kind::Symbol, P; kwargs...) = ADgradient(Val{kind}(), P; kwargs...)
 
-function ADgradient(v::Val{kind}, P; kwargs...) where kind
-    @info "Don't know how to AD with $(kind), consider `import $(kind)` if there is such a package."
-    throw(MethodError(ADgradient, (v, P)))
+# Better error message if users forget to load the AD package
+if isdefined(Base.Experimental, :register_error_hint)
+    _extract_val(::Val{T}) where {T} = T
+    function __init__()
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, _
+            if exc.f === ADgradient && length(argtypes) == 2 && first(argtypes) <: Val
+                kind = _extract_val(first(argtypes))
+                print(io, "\nDon't know how to AD with $(kind), consider `import $(kind)` if there is such a package.")
+            end
+        end
+    end
 end
 
 #####

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -295,8 +295,7 @@ end
 end
 
 @testset "ADgradient missing method" begin
-    msg = "Don't know how to AD with Foo, consider `import Foo` if there is such a package."
-    @test_logs((:info, msg), @test_throws(MethodError, ADgradient(:Foo, TestLogDensity2())))
+    @test_throws "Don't know how to AD with Foo, consider `import Foo` if there is such a package." ADgradient(:Foo, TestLogDensity2())
 end
 
 @testset "benchmark ForwardDiff chunk size" begin


### PR DESCRIPTION
The PR adds an error hint that tells users that maybe they forgot to load DifferentiationInterface in case `ADgradient(::AbstractADType, ...)` is not defined.

IMO manually throwing `MethodError`s is a bit questionable, therefore I also replaced the existing notification for undefined `ADgradient(::Val, ...)` with an error hint.

Fixes #41.